### PR TITLE
new "Helpful Libraries" & "RxAndroid" library

### DIFF
--- a/android/Useful_links.md
+++ b/android/Useful_links.md
@@ -97,3 +97,6 @@
 - [HoloGraphLibrary](https://github.com/Androguide/HoloGraphLibrary) - Newer graphing library
 - [AChartEngine](https://github.com/ddanny/achartengine) - This is a charting software library for Android applications
 - [MPAndroidChart](https://github.com/PhilJay/MPAndroidChart) - A powerful Android chart view / graph view library
+
+### Helpful Libraries
+- [RxAndroid](https://github.com/ReactiveX/RxAndroid) - Android specific bindings [Reactive Extensions](http://reactivex.io/) to write easy event-based and asynchronous programs using observable sequences.


### PR DESCRIPTION
Had to add new title as RxAndroid library doesn't go with any existing titles and it more of a sorts in to Helpful ones rather than necessary.