### PR TITLE
Add Huyen Dao in Android Experts to follow

### DIFF
--- a/android/experts_to_follow.md
+++ b/android/experts_to_follow.md
@@ -34,3 +34,4 @@ Romain Guy | https://twitter.com/romainguy | https://plus.google.com/+RomainGuy 
 Michael Evans | https://twitter.com/m_evans10 | https://plus.google.com/+MichaelEvans | http://michaelevans.org/
 Colt McAnlis | https://twitter.com/duhroach | https://plus.google.com/+ColtMcAnlis | http://mainroach.blogspot.in/ https://medium.com/@duhroach | https://www.linkedin.com/in/duhroach | https://www.youtube.com/playlist?list=PLWz5rJ2EKKc9CBxr3BVjPTPoDPLdPIFCE
 Lars Vogel | https://twitter.com/vogella | https://plus.google.com/+LarsVogel | http://vogella.com | https://de.linkedin.com/in/vogella | 
+Huyen Dao | https://twitter.com/queencodemonkey | https://plus.google.com/102581039328114075159 | http://www.randomlytyping.com/ | https://www.linkedin.com/in/huyentuedao | https://developers.google.com/experts/people/huyen-tue-dao


### PR DESCRIPTION
Huyen Dao is Google Developer Expert for Android, Android developer at Trello.